### PR TITLE
feat(admin/playable-species): wire frontend browse table to species e…

### DIFF
--- a/src/features/admin/components/playableDashboard/PlayableDashboardSidebarTools.vue
+++ b/src/features/admin/components/playableDashboard/PlayableDashboardSidebarTools.vue
@@ -118,7 +118,6 @@ const isManagePassivesModalOpen = ref(false)
 
 // 🚦 Action dispatcher
 function handleAction(action?: string) {
-  console.log('NEW SIDEBAR HANDLER FIRED:', action)
   if (!action) return
   switch (action) {
     case 'createClass':
@@ -131,6 +130,7 @@ function handleAction(action?: string) {
       store.refreshPlayableList()
       break
     case 'browseSpecies':
+      console.log('NEW SIDEBAR HANDLER FIRED:', action);
       isBrowseSpeciesModalOpen.value = true
       break
     case 'manageStats':

--- a/src/features/admin/components/playableDashboard/PlayableDashboardSidebarTools.vue
+++ b/src/features/admin/components/playableDashboard/PlayableDashboardSidebarTools.vue
@@ -50,6 +50,15 @@
     </AdminModal>
 
     <AdminModal
+      title="Browse Species"
+      :visible="isBrowseSpeciesModalOpen"
+      @close="isBrowseSpeciesModalOpen = false"
+      size="5xl"
+    >
+      <PlayableTableWidget />
+    </AdminModal>
+
+    <AdminModal
       title="Manage Passives"
       :visible="isManagePassivesModalOpen"
       @close="isManagePassivesModalOpen = false"
@@ -64,6 +73,7 @@ import { ref, computed, inject } from 'vue'
 import AppIcon from '@/components/atoms/AppIcon.vue'
 import ManageStatsModal from '@/features/admin/components/playableDashboard/ManageStatsModal.vue'
 import PlayableClassModal from '@/features/admin/components/playableDashboard/PlayableClassModal.vue'
+import PlayableTableWidget from '@/features/admin/components/playableDashboard/PlayableTableWidget.vue'
 import AdminModal from '@/features/admin/components/shared/AdminModal.vue'
 import { useAdminPlayableStore } from '@/features/admin/stores/adminPlayableStore'
 import type { AdminDashboardTool } from '@/features/admin/utils/adminDashboardTools'
@@ -102,6 +112,7 @@ function toggleSubmenu(tool: AdminDashboardTool) {
 
 // 📦 Modal states
 const isBrowseClassesModalOpen = ref(false)
+const isBrowseSpeciesModalOpen = ref(false)
 const isManageStatsModalOpen = ref(false)
 const isManagePassivesModalOpen = ref(false)
 
@@ -117,6 +128,9 @@ function handleAction(action?: string) {
       break
     case 'refreshClasses':
       store.refreshPlayableList()
+      break
+    case 'browseSpecies':
+      isBrowseSpeciesModalOpen.value = true
       break
     case 'manageStats':
       isManageStatsModalOpen.value = true

--- a/src/features/admin/components/playableDashboard/PlayableDashboardSidebarTools.vue
+++ b/src/features/admin/components/playableDashboard/PlayableDashboardSidebarTools.vue
@@ -118,6 +118,7 @@ const isManagePassivesModalOpen = ref(false)
 
 // 🚦 Action dispatcher
 function handleAction(action?: string) {
+  console.log('NEW SIDEBAR HANDLER FIRED:', action)
   if (!action) return
   switch (action) {
     case 'createClass':
@@ -142,7 +143,7 @@ function handleAction(action?: string) {
       emit('openTagsModal')
       break
     default:
-      console.log(`Unhandled action: ${action}`)
+      console.log('NEW DEFAULT HIT:', action)
   }
 }
 </script>

--- a/src/features/admin/components/playableDashboard/PlayableDashboardSidebarTools.vue
+++ b/src/features/admin/components/playableDashboard/PlayableDashboardSidebarTools.vue
@@ -130,7 +130,6 @@ function handleAction(action?: string) {
       store.refreshPlayableList()
       break
     case 'browseSpecies':
-      console.log('NEW SIDEBAR HANDLER FIRED:', action);
       isBrowseSpeciesModalOpen.value = true
       break
     case 'manageStats':
@@ -143,7 +142,7 @@ function handleAction(action?: string) {
       emit('openTagsModal')
       break
     default:
-      console.log('NEW DEFAULT HIT:', action)
+      console.log(`Unhandled action: ${action}`)
   }
 }
 </script>

--- a/src/features/admin/components/playableDashboard/PlayableTableWidget.vue
+++ b/src/features/admin/components/playableDashboard/PlayableTableWidget.vue
@@ -1,6 +1,6 @@
 <!-- /src/features/admin/components/playableDashboard/PlayableTableWidget.vue -->
 <template>
-  <WidgetWrapper title="Playable Class Table" icon="Table">
+  <WidgetWrapper title="Playable Species/Class Table" icon="Table">
     <template #hover-tools>
       <button
         @click="modalOpen = true"

--- a/src/features/admin/components/playableDashboard/PlayableTableWidget.vue
+++ b/src/features/admin/components/playableDashboard/PlayableTableWidget.vue
@@ -36,42 +36,29 @@
           <table class="min-w-full text-sm">
             <thead class="bg-gray-100 dark:bg-neutral-800">
               <tr>
+                <th class="px-4 py-2 text-left">Display Name</th>
                 <th class="px-4 py-2 text-left">Name</th>
-                <th class="px-4 py-2 text-left">Tags</th>
-                <th class="px-4 py-2 text-left">Playable</th>
+                <th class="px-4 py-2 text-left">Slug</th>
+                <th class="px-4 py-2 text-left">Active</th>
+                <th class="px-4 py-2 text-left">Sort Order</th>
                 <th class="px-4 py-2 text-left">Last Updated</th>
-                <th class="px-4 py-2 text-left">Actions</th>
               </tr>
             </thead>
             <tbody>
               <tr
-                v-for="char in classes"
-                :key="char.id"
+                v-for="item in species"
+                :key="item.id"
                 class="border-t dark:border-neutral-700"
               >
-                <td class="px-4 py-2 font-medium">{{ char.name }}</td>
+                <td class="px-4 py-2 font-medium">{{ item.displayName }}</td>
+                <td class="px-4 py-2">{{ item.name }}</td>
+                <td class="px-4 py-2">{{ item.slug }}</td>
                 <td class="px-4 py-2">
-                  <span
-                    v-for="tag in char.tags"
-                    :key="tag"
-                    class="mr-1 inline-block rounded bg-blue-100 px-2 py-0.5 text-xs text-blue-800 dark:bg-blue-900 dark:text-blue-100"
-                  >
-                    {{ tag }}
-                  </span>
+                  {{ item.isActive ? 'Yes' : 'No' }}
                 </td>
+                <td class="px-4 py-2">{{ item.sortOrder ?? '—' }}</td>
                 <td class="px-4 py-2">
-                  {{ char.isPlayable ? 'Yes' : 'No' }}
-                </td>
-                <td class="px-4 py-2">
-                  {{ formatDate(char.updatedAt) }}
-                </td>
-                <td class="px-4 py-2">
-                  <button
-                    @click="store.openEditModal(char)"
-                    class="text-blue-600 hover:underline"
-                  >
-                    Edit
-                  </button>
+                  {{ formatDate(item.updatedAt) }}
                 </td>
               </tr>
             </tbody>
@@ -89,24 +76,24 @@
 import { ref, onMounted, watch } from 'vue'
 import WidgetWrapper from '@/components/molecules/WidgetWrapper.vue'
 import AdminModal from '@/features/admin/components/shared/AdminModal.vue'
-import { playableClassService } from '@/features/admin/services/playableClassService'
+import { playableSpeciesService } from '@/features/admin/services/playableSpeciesService'
 import { useAdminPlayableStore } from '@/features/admin/stores/adminPlayableStore'
-import type { PlayableClass } from '@/features/admin/types/playableTypes'
+import type { PlayableSpeciesBrowseItem } from '@/features/admin/types/playableTypes'
 import PlayableClassModal from './PlayableClassModal.vue'
 
 const store = useAdminPlayableStore()
 const modalOpen = ref(false)
-const classes = ref<PlayableClass[]>([])
+const species = ref<PlayableSpeciesBrowseItem[]>([])
 
-async function fetchClasses() {
-  const res = await playableClassService.getPlayableClasses({ page: 1, limit: 50 })
-  classes.value = res.data
+async function fetchSpecies() {
+  const res = await playableSpeciesService.getPlayableSpecies()
+  species.value = res
 }
 
-function formatDate(dateStr: string) {
-  return new Date(dateStr).toLocaleDateString()
+function formatDate(dateStr: string | null) {
+  return dateStr ? new Date(dateStr).toLocaleDateString() : '—'
 }
 
-onMounted(fetchClasses)
-watch(() => store.lastPlayableRefresh, fetchClasses)
+onMounted(fetchSpecies)
+watch(() => store.lastPlayableRefresh, fetchSpecies)
 </script>

--- a/src/features/admin/components/playableDashboard/PlayableTableWidget.vue
+++ b/src/features/admin/components/playableDashboard/PlayableTableWidget.vue
@@ -1,6 +1,6 @@
 <!-- /src/features/admin/components/playableDashboard/PlayableTableWidget.vue -->
 <template>
-  <WidgetWrapper title="Playable Species/Class Table" icon="Table">
+  <WidgetWrapper title="Playable Species Table" icon="Table">
     <template #hover-tools>
       <button
         @click="modalOpen = true"
@@ -11,14 +11,14 @@
     </template>
 
     <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
-      View and manage all playable classes.
+      View and manage all playable species.
     </p>
 
     <AdminModal
       :visible="modalOpen"
       @close="modalOpen = false"
       size="6xl"
-      title="Manage Playable Classes"
+      title="Manage Playable Species"
     >
       <div class="space-y-4 text-gray-800 dark:text-gray-100">
         <!-- Create Button -->

--- a/src/features/admin/services/playableSpeciesService.ts
+++ b/src/features/admin/services/playableSpeciesService.ts
@@ -1,0 +1,13 @@
+// src/features/admin/services/playableSpeciesService.ts
+
+import { axiosInstance } from '@/services/axiosInstance'
+import type { PlayableSpeciesBrowseItem } from '@/features/admin/types/playableTypes'
+
+export async function getPlayableSpecies(): Promise<PlayableSpeciesBrowseItem[]> {
+  const response = await axiosInstance.get<PlayableSpeciesBrowseItem[]>('/admin/playable-species')
+  return response.data
+}
+
+export const playableSpeciesService = {
+  getPlayableSpecies,
+}

--- a/src/features/admin/types/playableTypes.ts
+++ b/src/features/admin/types/playableTypes.ts
@@ -13,3 +13,16 @@ export interface PlayableClass {
   createdAt: string
   updatedAt: string
 }
+
+export interface PlayableSpeciesBrowseItem {
+  id: string
+  name: string
+  slug: string
+  displayName: string
+  description: string | null
+  iconMediaAssetId: string | null
+  isActive: boolean | null
+  sortOrder: number | null
+  createdAt: string | null
+  updatedAt: string | null
+}


### PR DESCRIPTION
…ndpoint

- Added PlayableSpeciesBrowseItem type for backend-aligned data
- Updated playableSpeciesService to use shared type
- Refactored PlayableTableWidget to fetch species instead of classes
- Replaced table rendering to display species fields
- Established first frontend integration for Playable Species browse view